### PR TITLE
Specified which shell to use

### DIFF
--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -6,7 +6,7 @@
 
 ### Posix systems (MacOS, Linux...)
 1. Open up a Terminal.
-2. Type this command: `curl https://raw.githubusercontent.com/fosscord/fosscord/main/scripts/setup/setup.sh --output setup.sh && sh setup.sh`.
+2. Type this command: `curl https://raw.githubusercontent.com/fosscord/fosscord/main/scripts/setup/setup.sh --output setup.sh && bash setup.sh`.
 
 ## With automated scripts
 To use this method, you must have [Git](https://git-scm.com) as well as [NodeJS and NPM](https://nodejs.org) installed.
@@ -16,4 +16,4 @@ To use this method, you must have [Git](https://git-scm.com) as well as [NodeJS 
 
 ### Posix systems (MacOS, Linux...)
 1. Open up a Terminal.
-2. Type this command: `git clone https://github.com/fosscord/fosscord && sh ./fosscord/scripts/setup/setup.sh`.
+2. Type this command: `git clone https://github.com/fosscord/fosscord && bash ./fosscord/scripts/setup/setup.sh`.

--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -1,19 +1,16 @@
 # Getting Started
-## Without automated scripts
+To use this method, you must have [NodeJS and NPM](https://nodejs.org) installed.
+
 ### Windows
-1. Open up a Terminal.
-2. Type this command: `curl https://raw.githubusercontent.com/fosscord/fosscord/main/scripts/setup/setup.bat --output setup.bat && setup.bat`.
+1. Open cmd
+2. Type this command:
+```
+curl https://raw.githubusercontent.com/fosscord/fosscord/main/scripts/setup/setup.bat --output setup.bat && setup.bat
+```
 
-### Posix systems (MacOS, Linux...)
-1. Open up a Terminal.
-2. Type this command: `curl https://raw.githubusercontent.com/fosscord/fosscord/main/scripts/setup/setup.sh --output setup.sh && bash setup.sh`.
-
-## With automated scripts
-To use this method, you must have [Git](https://git-scm.com) as well as [NodeJS and NPM](https://nodejs.org) installed.
-### Windows
-1. Open up a Terminal.
-2. Type this command: `git clone https://github.com/fosscord/fosscord && .\fosscord\scripts\setup\setup.bat`.
-
-### Posix systems (MacOS, Linux...)
-1. Open up a Terminal.
-2. Type this command: `git clone https://github.com/fosscord/fosscord && bash ./fosscord/scripts/setup/setup.sh`.
+### Linux or macOS
+1. Open Terminal
+2. Type this command:
+```
+curl https://raw.githubusercontent.com/fosscord/fosscord/main/scripts/setup/setup.sh --output setup.sh && bash setup.sh
+```


### PR DESCRIPTION
The setup script is not POSIX complaint and throws an error when run with a pure POSIX shell. It is clearly designed for bash and so I have corrected the instructions to specify using bash.

The script is clearly designed for BASH. However, if you would like me to take the opposite approach to this issue and convert it to be POSIX compliant, I can do that.