### PR TITLE
Specified shell

### DIFF
--- a/scripts/setup/README.md
+++ b/scripts/setup/README.md
@@ -12,5 +12,5 @@ curl https://raw.githubusercontent.com/fosscord/fosscord/main/scripts/setup/setu
 1. Open Terminal
 2. Type this command:
 ```
-curl https://raw.githubusercontent.com/fosscord/fosscord/main/scripts/setup/setup.sh --output setup.sh && sh setup.sh
+curl https://raw.githubusercontent.com/fosscord/fosscord/main/scripts/setup/setup.sh --output setup.sh && bash setup.sh
 ```


### PR DESCRIPTION
The setup script is clearly designed for bash and is not posix compliant so this is necessary.

If you would prefer an POSIX complaint system, that can be arranged. However, my opinion is that this is the system that is far simpler for the user.